### PR TITLE
Implement Encounter class and tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "start": "node src/app.js",
     "dev": "nodemon src/app.js",
     "prisma:migrate": "prisma migrate deploy",
-    "prisma:generate": "prisma generate"
+    "prisma:generate": "prisma generate",
+    "test": "node --test"
   },
   "dependencies": {
     "@prisma/client": "^5.5.2",

--- a/src/lib/encounter.js
+++ b/src/lib/encounter.js
@@ -1,0 +1,14 @@
+class Encounter {
+  constructor() {
+    this.isActive = true;
+    this.startedAt = new Date();
+    this.endedAt = null;
+  }
+
+  end() {
+    this.isActive = false;
+    this.endedAt = new Date();
+  }
+}
+
+export default Encounter;

--- a/src/routes/dm.js
+++ b/src/routes/dm.js
@@ -1,18 +1,24 @@
 import express from 'express';
 import wss from '../lib/socket.js';
+import Encounter from '../lib/encounter.js';
 
 const router = express.Router();
 
 // TODO completely rework this
 router.post('/combat/start', async (req, res) => {
-  req.session.encounter = new Encounter();
-  wss.send('combat_start', req.session.encounter);
+  const encounter = new Encounter();
+  req.session.encounter = encounter;
+  wss.send('combat_start', encounter);
   res.sendStatus(200);
 });
 
 router.post('/combat/end', async (req, res) => {
+  const encounter = req.session.encounter;
+  if (encounter instanceof Encounter) {
+    encounter.end();
+  }
+  wss.send('combat_end', encounter);
   req.session.encounter = null;
-  wss.send('combat_end', req.session.encounter);
   res.sendStatus(200);
 });
 

--- a/test/dm.test.js
+++ b/test/dm.test.js
@@ -1,0 +1,41 @@
+import { test, after } from 'node:test';
+import assert from 'node:assert/strict';
+import router from '../src/routes/dm.js';
+import Encounter from '../src/lib/encounter.js';
+import wss from '../src/lib/socket.js';
+
+// silence socket broadcasts during tests
+wss.send = () => {};
+
+after(() => {
+  wss.close();
+});
+
+function getHandler(path) {
+  const layer = router.stack.find((l) => l.route && l.route.path === path);
+  return layer.route.stack[0].handle;
+}
+
+test('start encounter initializes session', async () => {
+  const handler = getHandler('/combat/start');
+  const req = { session: {} };
+  let status;
+  const res = { sendStatus: (code) => { status = code; } };
+
+  await handler(req, res);
+  assert.equal(status, 200);
+  assert.ok(req.session.encounter instanceof Encounter);
+  assert.equal(req.session.encounter.isActive, true);
+});
+
+test('end encounter clears session', async () => {
+  const handler = getHandler('/combat/end');
+  const encounter = new Encounter();
+  const req = { session: { encounter } };
+  let status;
+  const res = { sendStatus: (code) => { status = code; } };
+
+  await handler(req, res);
+  assert.equal(status, 200);
+  assert.equal(req.session.encounter, null);
+});


### PR DESCRIPTION
## Summary
- define `Encounter` class with start/end state
- integrate `Encounter` into `/dm/combat` routes
- add Node test script and tests for encounter start/end

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68606635adac83278e894331d692d3ee