### PR TITLE
Switch server entrypoint to ESM

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "start": "node src/app.js",
-    "dev": "nodemon src/app.js",
+    "start": "node src/bin/www",
+    "dev": "nodemon src/bin/www",
     "prisma:migrate": "prisma migrate deploy",
     "prisma:generate": "prisma generate"
   },

--- a/src/app.js
+++ b/src/app.js
@@ -88,9 +88,7 @@ app.use('/arena', arenaRoutes);
 app.use('/world', worldRoutes);
 app.use('/dm', dmRoutes);
 
-app.listen(3000, () => {
-  console.log('Listening for requests');
-});
+export default app;
 
 /**
  // Arena stuff

--- a/src/bin/www
+++ b/src/bin/www
@@ -3,9 +3,11 @@
 /**
  * Module dependencies.
  */
-const app = require('../app');
-const debug = require('debug')('daemios-api:server');
-const http = require('http');
+import app from '../app.js';
+import debugModule from 'debug';
+import http from 'http';
+
+const debug = debugModule('daemios-api:server');
 
 /**
  * Get port from environment and store in Express.


### PR DESCRIPTION
## Summary
- convert `src/bin/www` to `import` syntax
- export the Express app from `src/app.js`
- update npm scripts to use the `src/bin/www` entrypoint

## Testing
- `npx prisma --version`
- `npm start` *(fails: `@prisma/client` did not initialize)*

------
https://chatgpt.com/codex/tasks/task_e_6860665a0ce883279fb9b35b7d3a1f81